### PR TITLE
fixed error with expired token test

### DIFF
--- a/test/test-auth.js
+++ b/test/test-auth.js
@@ -172,12 +172,12 @@ describe('Auth endpoints', function () {
             firstName,
             lastName
           },
+          exp: Math.floor(Date.now() / 1000) - 10 // Expired ten seconds ago
         },
         JWT_SECRET,
         {
           algorithm: 'HS256',
-          subject: username,
-          expiresIn: Math.floor(Date.now() / 1000) - 10 // Expired ten seconds ago
+          subject: username
         }
       );
 


### PR DESCRIPTION
The test was originally written with the expired date under "expiresIn". The test failed as it didn't create an expired token. It should pass now.